### PR TITLE
fix(composer): this changes guzzle version to ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "minimum-stability": "dev",
   "require": {
-    "guzzlehttp/guzzle": "^6.3"
+    "guzzlehttp/guzzle": "^6.3 || ^7.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.0",


### PR DESCRIPTION
Этот коммит добавляет возможность использование версии на `guzzlehttp/guzzle: "^6.3 || ^7.0"`, что позволяет использовать библиотеку на последних версиях guzzle при сохранении обратной совместимости. 

Данные изменения были протестированы с помощью тестов:
```bash
➜  yandex-market-php-common git:(pr-guzzle7) ✗ ./vendor/bin/phpunit tests
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

.................                                                 17 / 17 (100%)

Time: 76 ms, Memory: 4.00MB

OK (17 tests, 17 assertions)
```

Кроме этого, была протестирована родительская библиотека https://github.com/yandex-market/yandex-market-php-partner  , которая использовала модифицированную библиотеку yandex-market/yandex-market-php-common с версиями guzzle 7.0.0 и 7.4.1, и каких-либо проблем или ошибок обнаружено не было. 

@VitaliaSmaglenko @MarketLLC , очень прошу принять данный PR, т.к. от этой проблемы страдаем не только лишь мы, а другие 8+ человек (см Issue #2 ). 
